### PR TITLE
Add --no-ipv6 and --security-group options

### DIFF
--- a/ec2-boot-bench/main.c
+++ b/ec2-boot-bench/main.c
@@ -29,6 +29,7 @@ static const char * ami_id = NULL;
 static const char * itype = NULL;
 static const char * keyfile = NULL;
 static const char * region = NULL;
+static const char * security_group = NULL;
 static const char * subnet_id = NULL;
 static const char * user_data_fname = NULL;
 static char * key_id;
@@ -181,6 +182,7 @@ launch(void)
 	    "InstanceType=%s&"
 	    "NetworkInterface.1.DeviceIndex=0&"
 	    "%s%s%s"
+	    "%s%s%s"
 	    "NetworkInterface.1.%s&"
 	    "%s%s%s"
 	    "MinCount=1&MaxCount=1&"
@@ -189,6 +191,9 @@ launch(void)
 	    subnet_id ? "NetworkInterface.1.SubnetId=" : "",
 	    subnet_id ? subnet_id : "",
 	    subnet_id ? "&" : "",
+	    security_group ? "NetworkInterface.1.SecurityGroupId.1=" : "",
+	    security_group ? security_group : "",
+	    security_group ? "&" : "",
 	    ipv6 ? "Ipv6AddressCount=1" : "AssociatePublicIpAddress=true",
 	    user_data_fname ? "UserData=" : "",
 	    user_data_fname ? userdatahexbuf : "",
@@ -673,9 +678,10 @@ static void
 usage(void)
 {
 
-	fprintf(stderr, "usage: ec2-boot-bench %s %s %s %s [%s] [%s] [%s]\n",
+	fprintf(stderr, "usage: ec2-boot-bench %s %s %s %s [%s] [%s] [%s] [%s]\n",
 	    "--keys <keyfile>", "--region <name>", "--ami <AMI Id>",
-	    "--itype <instance type>", "--no-ipv6", "--subnet <subnet Id>",
+	    "--itype <instance type>", "--no-ipv6",
+	    "--security-group <security group Id>", "--subnet <subnet Id>",
 	    "--user-data <file>");
 	exit(1);
 }
@@ -705,6 +711,9 @@ main(int argc, char * argv[])
 			break;
 		GETOPT_OPTARG("--region"):
 			region = optarg;
+			break;
+		GETOPT_OPTARG("--security-group"):
+			security_group = optarg;
 			break;
 		GETOPT_OPTARG("--subnet"):
 			subnet_id = optarg;

--- a/ec2-boot-bench/main.c
+++ b/ec2-boot-bench/main.c
@@ -45,6 +45,7 @@ static struct timeval t_open;
 static size_t ndescribes = 0;
 static size_t npings = 0;
 static int terminated = 0;
+static int ipv6 = 1;
 
 static int poke(void);
 
@@ -178,15 +179,17 @@ launch(void)
 	    "Action=RunInstances&"
 	    "ImageId=%s&"
 	    "InstanceType=%s&"
+	    "NetworkInterface.1.DeviceIndex=0&"
 	    "%s%s%s"
+	    "NetworkInterface.1.%s&"
 	    "%s%s%s"
 	    "MinCount=1&MaxCount=1&"
-	    "Ipv6AddressCount=1&"
 	    "Version=2016-11-15",
 	    ami_id, itype,
-	    subnet_id ? "SubnetId=" : "",
+	    subnet_id ? "NetworkInterface.1.SubnetId=" : "",
 	    subnet_id ? subnet_id : "",
 	    subnet_id ? "&" : "",
+	    ipv6 ? "Ipv6AddressCount=1" : "AssociatePublicIpAddress=true",
 	    user_data_fname ? "UserData=" : "",
 	    user_data_fname ? userdatahexbuf : "",
 	    user_data_fname ? "&" : "") == -1)
@@ -670,9 +673,9 @@ static void
 usage(void)
 {
 
-	fprintf(stderr, "usage: ec2-boot-bench %s %s %s %s [%s] [%s]\n",
+	fprintf(stderr, "usage: ec2-boot-bench %s %s %s %s [%s] [%s] [%s]\n",
 	    "--keys <keyfile>", "--region <name>", "--ami <AMI Id>",
-	    "--itype <instance type>", "--subnet <subnet Id>",
+	    "--itype <instance type>", "--no-ipv6", "--subnet <subnet Id>",
 	    "--user-data <file>");
 	exit(1);
 }
@@ -696,6 +699,9 @@ main(int argc, char * argv[])
 			break;
 		GETOPT_OPTARG("--keys"):
 			keyfile = optarg;
+			break;
+		GETOPT_OPT("--no-ipv6"):
+			ipv6 = 0;
 			break;
 		GETOPT_OPTARG("--region"):
 			region = optarg;


### PR DESCRIPTION
Add a --no-ipv6 option for use on IPv4-only networks. In the process, switch to
specifying a network interface, so that in the IPv4 case, we can specify
`AssociatePublicIpAddress=true` to get a routable address.

Add a `--security-group` option to specify a security group. This makes it
possible to specify a security group that allows inbound port 22, to allow
testing from outside the VPC.
