### PR TITLE
Add a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.a
+*.o
+
+/cflags-filter.sh
+/cpusupport-config.h
+/ec2-boot-bench/ec2-boot-bench
+/posix-flags.sh


### PR DESCRIPTION
This makes `git status` show up clean after a build, and prevents `gh pr
create` from warning about uncommitted files when submitting pull
requests.
