### PR TITLE
Fix build on macOS

### DIFF
--- a/ec2-boot-bench/main.c
+++ b/ec2-boot-bench/main.c
@@ -1,3 +1,7 @@
+#if defined(__APPLE__)
+#define _DARWIN_C_SOURCE
+#endif
+
 #include <sys/socket.h>
 
 #include <assert.h>


### PR DESCRIPTION
Not sure if this is the right way to go about fixing this (my C skills are read-only really), but this fixes 

```
main.c:1079:7: error: implicit declaration of function 'mkdtemp' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                if (mkdtemp(screenshotdir) == NULL) {
                    ^
```

when building on my Mac (macOS 12.5/Apple Silicon).

Thanks!